### PR TITLE
Changes cursor, link and selection colors to match emacs'

### DIFF
--- a/challenger-deep.itermcolors
+++ b/challenger-deep.itermcolors
@@ -4,256 +4,341 @@
 <dict>
 	<key>Ansi 0 Color</key>
 	<dict>
+		<key>Alpha Component</key>
+		<real>1</real>
+		<key>Blue Component</key>
+		<real>0.45882353186607361</real>
 		<key>Color Space</key>
 		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.4588235294117647</real>
 		<key>Green Component</key>
-		<real>0.3333333333333333</real>
+		<real>0.3333333432674408</real>
 		<key>Red Component</key>
-		<real>0.33725490196078434</real>
+		<real>0.33725491166114807</real>
 	</dict>
 	<key>Ansi 1 Color</key>
 	<dict>
+		<key>Alpha Component</key>
+		<real>1</real>
+		<key>Blue Component</key>
+		<real>0.50196081399917603</real>
 		<key>Color Space</key>
 		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.5019607843137255</real>
 		<key>Green Component</key>
-		<real>0.5019607843137255</real>
+		<real>0.50196081399917603</real>
 		<key>Red Component</key>
 		<real>1</real>
 	</dict>
 	<key>Ansi 10 Color</key>
 	<dict>
+		<key>Alpha Component</key>
+		<real>1</real>
+		<key>Blue Component</key>
+		<real>0.58823531866073608</real>
 		<key>Color Space</key>
 		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.5882352941176471</real>
 		<key>Green Component</key>
-		<real>0.8196078431372549</real>
+		<real>0.81960785388946533</real>
 		<key>Red Component</key>
-		<real>0.3843137254901961</real>
+		<real>0.38431373238563538</real>
 	</dict>
 	<key>Ansi 11 Color</key>
 	<dict>
+		<key>Alpha Component</key>
+		<real>1</real>
+		<key>Blue Component</key>
+		<real>0.47058823704719543</real>
 		<key>Color Space</key>
 		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.47058823529411764</real>
 		<key>Green Component</key>
-		<real>0.7019607843137254</real>
+		<real>0.70196080207824707</real>
 		<key>Red Component</key>
 		<real>1</real>
 	</dict>
 	<key>Ansi 12 Color</key>
 	<dict>
-		<key>Color Space</key>
-		<string>sRGB</string>
+		<key>Alpha Component</key>
+		<real>1</real>
 		<key>Blue Component</key>
 		<real>1</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.6980392156862745</real>
+		<real>0.69803923368453979</real>
 		<key>Red Component</key>
-		<real>0.396078431372549</real>
+		<real>0.3960784375667572</real>
 	</dict>
 	<key>Ansi 13 Color</key>
 	<dict>
-		<key>Color Space</key>
-		<string>sRGB</string>
+		<key>Alpha Component</key>
+		<real>1</real>
 		<key>Blue Component</key>
 		<real>1</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.4235294117647059</real>
+		<real>0.42352941632270813</real>
 		<key>Red Component</key>
-		<real>0.5647058823529412</real>
+		<real>0.56470590829849243</real>
 	</dict>
 	<key>Ansi 14 Color</key>
 	<dict>
+		<key>Alpha Component</key>
+		<real>1</real>
+		<key>Blue Component</key>
+		<real>0.94509804248809814</real>
 		<key>Color Space</key>
 		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.9450980392156862</real>
 		<key>Green Component</key>
-		<real>0.9490196078431372</real>
+		<real>0.94901961088180542</real>
 		<key>Red Component</key>
-		<real>0.38823529411764707</real>
+		<real>0.38823530077934265</real>
 	</dict>
 	<key>Ansi 15 Color</key>
 	<dict>
+		<key>Alpha Component</key>
+		<real>1</real>
+		<key>Blue Component</key>
+		<real>0.80000001192092896</real>
 		<key>Color Space</key>
 		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.8</real>
 		<key>Green Component</key>
-		<real>0.7019607843137254</real>
+		<real>0.70196080207824707</real>
 		<key>Red Component</key>
-		<real>0.6509803921568628</real>
+		<real>0.65098041296005249</real>
 	</dict>
 	<key>Ansi 2 Color</key>
 	<dict>
+		<key>Alpha Component</key>
+		<real>1</real>
+		<key>Blue Component</key>
+		<real>0.64313727617263794</real>
 		<key>Color Space</key>
 		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.6431372549019608</real>
 		<key>Green Component</key>
 		<real>1</real>
 		<key>Red Component</key>
-		<real>0.5843137254901961</real>
+		<real>0.58431375026702881</real>
 	</dict>
 	<key>Ansi 3 Color</key>
 	<dict>
+		<key>Alpha Component</key>
+		<real>1</real>
+		<key>Blue Component</key>
+		<real>0.66666668653488159</real>
 		<key>Color Space</key>
 		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.6666666666666666</real>
 		<key>Green Component</key>
-		<real>0.9137254901960784</real>
+		<real>0.91372549533843994</real>
 		<key>Red Component</key>
 		<real>1</real>
 	</dict>
 	<key>Ansi 4 Color</key>
 	<dict>
-		<key>Color Space</key>
-		<string>sRGB</string>
+		<key>Alpha Component</key>
+		<real>1</real>
 		<key>Blue Component</key>
 		<real>1</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.8666666666666667</real>
+		<real>0.86666667461395264</real>
 		<key>Red Component</key>
-		<real>0.5686274509803921</real>
+		<real>0.56862747669219971</real>
 	</dict>
 	<key>Ansi 5 Color</key>
 	<dict>
+		<key>Alpha Component</key>
+		<real>1</real>
+		<key>Blue Component</key>
+		<real>0.88235294818878174</real>
 		<key>Color Space</key>
 		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.8823529411764706</real>
 		<key>Green Component</key>
-		<real>0.5686274509803921</real>
+		<real>0.56862747669219971</real>
 		<key>Red Component</key>
-		<real>0.788235294117647</real>
+		<real>0.78823530673980713</real>
 	</dict>
 	<key>Ansi 6 Color</key>
 	<dict>
+		<key>Alpha Component</key>
+		<real>1</real>
+		<key>Blue Component</key>
+		<real>0.89411765336990356</real>
 		<key>Color Space</key>
 		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.8941176470588236</real>
 		<key>Green Component</key>
 		<real>1</real>
 		<key>Red Component</key>
-		<real>0.6666666666666666</real>
+		<real>0.66666668653488159</real>
 	</dict>
 	<key>Ansi 7 Color</key>
 	<dict>
+		<key>Alpha Component</key>
+		<real>1</real>
+		<key>Blue Component</key>
+		<real>0.90588235855102539</real>
 		<key>Color Space</key>
 		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.9058823529411765</real>
 		<key>Green Component</key>
-		<real>0.8901960784313725</real>
+		<real>0.89019608497619629</real>
 		<key>Red Component</key>
-		<real>0.796078431372549</real>
+		<real>0.79607844352722168</real>
 	</dict>
 	<key>Ansi 8 Color</key>
 	<dict>
+		<key>Alpha Component</key>
+		<real>1</real>
+		<key>Blue Component</key>
+		<real>0.13725490868091583</real>
 		<key>Color Space</key>
 		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.13725490196078433</real>
 		<key>Green Component</key>
-		<real>0.054901960784313725</real>
+		<real>0.054901961237192154</real>
 		<key>Red Component</key>
-		<real>0.06274509803921569</real>
+		<real>0.062745101749897003</real>
 	</dict>
 	<key>Ansi 9 Color</key>
 	<dict>
+		<key>Alpha Component</key>
+		<real>1</real>
+		<key>Blue Component</key>
+		<real>0.34509804844856262</real>
 		<key>Color Space</key>
 		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.34509803921568627</real>
 		<key>Green Component</key>
-		<real>0.32941176470588235</real>
+		<real>0.32941177487373352</real>
 		<key>Red Component</key>
 		<real>1</real>
 	</dict>
 	<key>Background Color</key>
 	<dict>
+		<key>Alpha Component</key>
+		<real>1</real>
+		<key>Blue Component</key>
+		<real>0.17254902422428131</real>
 		<key>Color Space</key>
 		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.17254901960784313</real>
 		<key>Green Component</key>
-		<real>0.09411764705882353</real>
+		<real>0.094117648899555206</real>
 		<key>Red Component</key>
-		<real>0.10588235294117647</real>
+		<real>0.10588235408067703</real>
+	</dict>
+	<key>Badge Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>0.5</real>
+		<key>Blue Component</key>
+		<real>0.0</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.1491314172744751</real>
+		<key>Red Component</key>
+		<real>1</real>
 	</dict>
 	<key>Bold Color</key>
 	<dict>
+		<key>Alpha Component</key>
+		<real>1</real>
+		<key>Blue Component</key>
+		<real>0.90588235855102539</real>
 		<key>Color Space</key>
 		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.9058823529411765</real>
 		<key>Green Component</key>
-		<real>0.8901960784313725</real>
+		<real>0.89019608497619629</real>
 		<key>Red Component</key>
-		<real>0.796078431372549</real>
+		<real>0.79607844352722168</real>
 	</dict>
 	<key>Cursor Color</key>
 	<dict>
+		<key>Alpha Component</key>
+		<real>1</real>
+		<key>Blue Component</key>
+		<real>0.90588235855102539</real>
 		<key>Color Space</key>
 		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.9058823529411765</real>
 		<key>Green Component</key>
-		<real>0.8901960784313725</real>
+		<real>0.89019608497619629</real>
 		<key>Red Component</key>
-		<real>0.796078431372549</real>
+		<real>0.79607844352722168</real>
+	</dict>
+	<key>Cursor Guide Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>0.25</real>
+		<key>Blue Component</key>
+		<real>1</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.9268307089805603</real>
+		<key>Red Component</key>
+		<real>0.70213186740875244</real>
 	</dict>
 	<key>Cursor Text Color</key>
 	<dict>
+		<key>Alpha Component</key>
+		<real>1</real>
+		<key>Blue Component</key>
+		<real>0.17254902422428131</real>
 		<key>Color Space</key>
 		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.17254901960784313</real>
 		<key>Green Component</key>
-		<real>0.09411764705882353</real>
+		<real>0.094117648899555206</real>
 		<key>Red Component</key>
-		<real>0.10588235294117647</real>
+		<real>0.10588235408067703</real>
 	</dict>
 	<key>Foreground Color</key>
 	<dict>
+		<key>Alpha Component</key>
+		<real>1</real>
+		<key>Blue Component</key>
+		<real>0.90588235855102539</real>
 		<key>Color Space</key>
 		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.9058823529411765</real>
 		<key>Green Component</key>
-		<real>0.8901960784313725</real>
+		<real>0.89019608497619629</real>
 		<key>Red Component</key>
-		<real>0.796078431372549</real>
+		<real>0.79607844352722168</real>
+	</dict>
+	<key>Link Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>1</real>
+		<key>Blue Component</key>
+		<real>0.73423302173614502</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.35916060209274292</real>
+		<key>Red Component</key>
+		<real>0.0</real>
 	</dict>
 	<key>Selected Text Color</key>
 	<dict>
+		<key>Alpha Component</key>
+		<real>1</real>
+		<key>Blue Component</key>
+		<real>0.90588235855102539</real>
 		<key>Color Space</key>
 		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.9058823529411765</real>
 		<key>Green Component</key>
-		<real>0.8901960784313725</real>
+		<real>0.89019608497619629</real>
 		<key>Red Component</key>
-		<real>0.796078431372549</real>
+		<real>0.79607844352722168</real>
 	</dict>
 	<key>Selection Color</key>
 	<dict>
+		<key>Alpha Component</key>
+		<real>1</real>
+		<key>Blue Component</key>
+		<real>0.17254902422428131</real>
 		<key>Color Space</key>
 		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.17254901960784313</real>
 		<key>Green Component</key>
-		<real>0.09411764705882353</real>
+		<real>0.094117648899555206</real>
 		<key>Red Component</key>
-		<real>0.10588235294117647</real>
+		<real>0.10588235408067703</real>
 	</dict>
 </dict>
 </plist>


### PR DESCRIPTION
Before:

![screen shot 2018-08-17 at 13 56 00](https://user-images.githubusercontent.com/66819/44283262-2e161b80-a234-11e8-845b-8308e8c144af.png)

After:

![screen shot 2018-08-17 at 15 33 26](https://user-images.githubusercontent.com/66819/44283269-31110c00-a234-11e8-8d44-fbeff9b6af42.png)
